### PR TITLE
FOFBApp: copy raw current setpoint value into current.

### DIFF
--- a/FOFBApp/Db/FOFBRtm.template
+++ b/FOFBApp/Db/FOFBRtm.template
@@ -265,6 +265,15 @@ record(longout,"$(S)$(RTM_CHAN)CurrentRaw-SP"){
     field(PINI,"YES")
 }
 
+record(calcout,"$(S)$(RTM_CHAN)CurrentRawPropagateSP"){
+    field(SCAN,"Passive")
+    field(INPA,"$(S)$(RTM_CHAN)CurrentRaw-SP CP")
+    field(INPB,"$(S)$(RTM_CHAN)CurrGain-SP")
+    field(INPC,"$(S)$(RTM_CHAN)CurrOffset-SP")
+    field(CALC,"B*(A-C)")
+    field(OUT,"$(S)$(RTM_CHAN)Current-SP NPP")
+}
+
 record(longin,"$(S)$(RTM_CHAN)CurrentRaw-RB"){
     field(DTYP,"asynInt32")
     field(DESC,"get manual current control (raw)")


### PR DESCRIPTION
This has been requested by operators so the value in Current-SP always reflects the one set in CurrentRaw-SP, even when the latter is the one being used to control the current source.